### PR TITLE
Add option to pass cacert file

### DIFF
--- a/conf/install-artifacts.sh
+++ b/conf/install-artifacts.sh
@@ -2,19 +2,21 @@
 
 function usage {
       echo ""
-      echo "usage: install-artifacts.sh -u <username> -p <password> -e <endpoint>"
+      echo "usage: install-artifacts.sh -u <username> -p <password> -e <endpoint> -c <cacert>"
       echo "    -u  elasticsearch username"
       echo "    -p  elasticsearch password"
       echo "    -e  elasticsearch endpoint, e.g. https://localhost:9200"
+      echo "    -c  cacert file (optional)"
       echo ""
 }
 
 username=""
 password=""
 endpoint=""
+cacert=""
 auth=""
 
-while getopts ":u:p:e:h" opt; do
+while getopts ":u:p:e:c:h" opt; do
   case $opt in
     u)
       username=$OPTARG
@@ -24,6 +26,9 @@ while getopts ":u:p:e:h" opt; do
       ;;
     e)
       endpoint=$OPTARG 
+      ;;
+    c)
+      cacert="--cacert $OPTARG"
       ;;
     h)
       usage
@@ -51,11 +56,11 @@ fi
 
 echo ""
 echo "Installing ingest pipeline to $endpoint for daily indices"
-curl -X PUT $auth "$endpoint/_ingest/pipeline/cloudflare-pipeline-daily" -H 'Content-Type: application/json' -d @cloudflare-ingest-pipeline-daily.json
+curl -X PUT $auth $cacert "$endpoint/_ingest/pipeline/cloudflare-pipeline-daily" -H 'Content-Type: application/json' -d @cloudflare-ingest-pipeline-daily.json
 echo ""
 echo "Installing ingest pipeline to $endpoint for weekly indices"
-curl -X PUT $auth "$endpoint/_ingest/pipeline/cloudflare-pipeline-weekly" -H 'Content-Type: application/json' -d @cloudflare-ingest-pipeline-weekly.json
+curl -X PUT $auth $cacert "$endpoint/_ingest/pipeline/cloudflare-pipeline-weekly" -H 'Content-Type: application/json' -d @cloudflare-ingest-pipeline-weekly.json
 echo ""
 echo "Installing index template to $endpoint"
-curl -X PUT $auth "$endpoint/_template/cloudflare" -H 'Content-Type: application/json' -d @cloudflare-index-template.json
+curl -X PUT $auth $cacert "$endpoint/_template/cloudflare" -H 'Content-Type: application/json' -d @cloudflare-index-template.json
 echo ""


### PR DESCRIPTION
This pull request add an optional parameter to pass a cacert.
Self-hosted elasticsearch usually need to pass a cacert file to validate certificate.